### PR TITLE
Exit 0 when analysisFiles is empty 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to test the code for this engine locally, you'll need to install [do
 
 Build the docker image with docker `docker build -t codeclimate/codeclimate-stylelint .` (You must be inside the project directory to do this)
 
-To run the tests, cd into `tests/` and run `sh setup.sh` 
+To run the tests, cd into `test/` and run `sh setup.sh` 
 
 ### Installation
 

--- a/bin/codeclimate-stylelint
+++ b/bin/codeclimate-stylelint
@@ -128,7 +128,7 @@ function configEngine() {
     if (!analysisFiles.length) {
       console.error(`No files to lint with the extensions: "${options.extensions.join('", "')}".`);
       console.error('See our documentation at https://docs.codeclimate.com/docs/stylelint for more information.');
-      process.exit(1);
+      process.exit(0);
     }
 
     const userConfig = engineConfig.config || {};
@@ -186,7 +186,7 @@ function analyzeFiles() {
         console.error(`Error: ${error.message}`);
       }
       console.error('See our documentation at https://docs.codeclimate.com/docs/stylelint for more information.');
-      process.exit(1);
+      process.exit(0);
     });
 }
 

--- a/test/stylelint-no-files/.codeclimate.yml
+++ b/test/stylelint-no-files/.codeclimate.yml
@@ -1,0 +1,12 @@
+---
+engines:
+  stylelint:
+    enabled: true
+    config:
+      ignore_warnings: true
+ratings:
+  paths:
+  - "**.scss"
+  - "**.less"
+exclude_paths:
+  - node_modules/**/*

--- a/test/stylelint-no-files/.stylelintrc
+++ b/test/stylelint-no-files/.stylelintrc
@@ -1,0 +1,156 @@
+{
+  "rules": {
+    "at-rule-empty-line-before": [ "always", {
+      "except": [
+        "blockless-after-same-name-blockless",
+        "first-nested"
+      ],
+      "ignore": ["after-comment"]
+    } ],
+    "at-rule-name-case": "lower",
+    "at-rule-name-space-after": "always-single-line",
+    "at-rule-semicolon-newline-after": "always",
+    "block-closing-brace-empty-line-before": "never",
+    "block-closing-brace-newline-after": "always",
+    "block-closing-brace-newline-before": "always-multi-line",
+    "block-closing-brace-space-before": "always-single-line",
+    "block-no-empty": true,
+    "block-opening-brace-newline-after": "always-multi-line",
+    "block-opening-brace-space-after": "always-single-line",
+    "block-opening-brace-space-before": "always",
+    "color-hex-case": "lower",
+    "color-hex-length": "short",
+    "color-no-invalid-hex": true,
+    "comment-empty-line-before": [ "always", {
+      "except": ["first-nested"],
+      "ignore": ["stylelint-commands"]
+    } ],
+    "comment-no-empty": true,
+    "comment-whitespace-inside": "always",
+    "custom-property-empty-line-before": [ "always", {
+      "except": [
+        "after-custom-property",
+        "first-nested"
+      ],
+      "ignore": [
+        "after-comment",
+        "inside-single-line-block"
+      ]
+    } ],
+    "declaration-bang-space-after": "never",
+    "declaration-bang-space-before": "always",
+    "declaration-block-no-duplicate-properties": [ true, {
+      "ignore": ["consecutive-duplicates-with-different-values"]
+    } ],
+    "declaration-block-no-ignored-properties": true,
+    "declaration-block-no-redundant-longhand-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-block-semicolon-space-after": "always-single-line",
+    "declaration-block-semicolon-space-before": "never",
+    "declaration-block-single-line-max-declarations": 1,
+    "declaration-block-trailing-semicolon": "always",
+    "declaration-colon-newline-after": "always-multi-line",
+    "declaration-colon-space-after": "always-single-line",
+    "declaration-colon-space-before": "never",
+    "declaration-empty-line-before": [ "always", {
+      "except": [
+        "after-declaration",
+        "first-nested"
+      ],
+      "ignore": [
+        "after-comment",
+        "inside-single-line-block"
+      ]
+    } ],
+    "function-calc-no-unspaced-operator": true,
+    "function-comma-newline-after": "always-multi-line",
+    "function-comma-space-after": "always-single-line",
+    "function-comma-space-before": "never",
+    "function-linear-gradient-no-nonstandard-direction": true,
+    "function-max-empty-lines": 0,
+    "function-name-case": "lower",
+    "function-parentheses-newline-inside": "always-multi-line",
+    "function-parentheses-space-inside": "never-single-line",
+    "function-whitespace-after": "always",
+    "indentation": 2,
+    "keyframe-declaration-no-important": true,
+    "length-zero-no-unit": true,
+    "max-empty-lines": 1,
+    "media-feature-colon-space-after": "always",
+    "media-feature-colon-space-before": "never",
+    "media-feature-name-case": "lower",
+    "media-feature-name-no-unknown": true,
+    "media-feature-no-missing-punctuation": true,
+    "media-feature-parentheses-space-inside": "never",
+    "media-feature-range-operator-space-after": "always",
+    "media-feature-range-operator-space-before": "always",
+    "media-query-list-comma-newline-after": "always-multi-line",
+    "media-query-list-comma-space-after": "always-single-line",
+    "media-query-list-comma-space-before": "never",
+    "no-empty-source": true,
+    "no-eol-whitespace": true,
+    "no-extra-semicolons": true,
+    "no-invalid-double-slash-comments": true,
+    "no-missing-end-of-source-newline": true,
+    "number-leading-zero": "always",
+    "number-no-trailing-zeros": true,
+    "property-case": "lower",
+    "property-no-unknown": true,
+    "rule-nested-empty-line-before": [ "always-multi-line", {
+      "except": ["first-nested"],
+      "ignore": ["after-comment"]
+    } ],
+    "rule-non-nested-empty-line-before": [ "always-multi-line", {
+      "ignore": ["after-comment"]
+    } ],
+    "selector-attribute-brackets-space-inside": "never",
+    "selector-attribute-operator-space-after": "never",
+    "selector-attribute-operator-space-before": "never",
+    "selector-combinator-space-after": "always",
+    "selector-combinator-space-before": "always",
+    "selector-descendant-combinator-no-non-space": true,
+    "selector-list-comma-newline-after": "always",
+    "selector-list-comma-space-before": "never",
+    "selector-max-empty-lines": 0,
+    "selector-no-empty": true,
+    "selector-pseudo-class-case": "lower",
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-class-parentheses-space-inside": "never",
+    "selector-pseudo-element-case": "lower",
+    "selector-pseudo-element-colon-notation": "double",
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-case": "lower",
+    "selector-type-no-unknown": true,
+    "shorthand-property-no-redundant-values": true,
+    "string-no-newline": true,
+    "unit-case": "lower",
+    "unit-no-unknown": true,
+    "value-list-comma-newline-after": "always-multi-line",
+    "value-list-comma-space-after": "always-single-line",
+    "value-list-comma-space-before": "never",
+    "value-list-max-empty-lines": 0,
+    "color-named": "never",
+    "declaration-block-properties-order": ["alphabetical", { "severity": "warning" }],
+    "declaration-property-value-blacklist": {
+      "/^border/": ["none"]
+    },
+    "function-url-quotes": "always",
+    "max-nesting-depth": 4,
+    "no-duplicate-selectors": true,
+    "number-max-precision": 4,
+    "property-no-vendor-prefix": true,
+    "selector-class-pattern": "^((?:-{1,2}|_{2})?[a-z0-9]+(?:(?:-{1,2}|_{2})[a-z0-9]+)*)(?:-{1,2}|_{2})?$",
+    "selector-max-compound-selectors": 4,
+    "selector-max-specificity": ["0,3,0"],
+    "selector-no-qualifying-type": [true, { "ignore": ["class"] }],
+    "string-quotes": "single",
+    "unit-blacklist": [
+      ["px", "em"], {
+        "ignoreProperties": {
+          "px": ["max-width"]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Engine shouldn't error when `analysisFiles` is empty. This is common when running `codeclimate analyze` in a single non "style" file. See #8 for details.

If you want to test this locally:
- Clone the right branch: https://github.com/leonelgalan/codeclimate-stylelint/tree/exit-0
- Get into the folder and run the tests: `cd test && sh setup.sh && cd ..`
- Build the image locally `docker build -t codeclimate/codeclimate-stylelint .`