### PR TITLE
Upgrade to stylelint 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^7.1.1",
     "rimraf": "^2.6.1",
     "simple-git": "^1.69.0",
-    "stylelint": "^7.10.1",
+    "stylelint": "^8.0.0",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-config-wordpress": "^9.1.1",
     "stylelint-csstree-validator": "^1.1.1",


### PR DESCRIPTION
Upgrading to stylelint 8 includes:

* deprecating rules, bug fixes, etc.
* upgrading postcss from v5 to v6