### PR TITLE
Adds stylelint-config-sass-guidelines, updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stylelint is a tool to help you enforce consistent conventions and avoid errors 
 
 ### Development
 
-If you want to test the code for this engine locally, you'll need to install [docker](https://www.docker.com/).  
+If you want to test the code for this engine locally, you'll need to install [docker](https://www.docker.com/).
 
 Build the docker image with docker `docker build -t codeclimate/codeclimate-stylelint .` (You must be inside the project directory to do this)
 
@@ -30,6 +30,7 @@ To run the tests, cd into `tests/` and run `sh setup.sh`
 - [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard/): The standard shareable config for stylelint
 - [stylelint-config-wordpress](https://github.com/ntwb/stylelint-config-wordpress/): WordPress CSS Coding Standards shareable config for stylelint
 - [stylelint-config-suitcss](https://github.com/suitcss/stylelint-config-suitcss): SUIT CSS config for stylelint
+- [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines): A stylelint config based on https://sass-guidelin.es/
 
 ### Plugins
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "stylelint-config-standard": "^17.0.0",
     "stylelint-config-suitcss": "^11.0.0",
     "stylelint-config-wordpress": "^12.0.0",
+    "stylelint-config-sass-guidelines": "^3.1.0",
     "stylelint-csstree-validator": "^1.1.1",
     "stylelint-declaration-strict-value": "^1.0.4",
     "stylelint-declaration-use-variable": "^1.6.0",


### PR DESCRIPTION
This adds [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines) as an available plugin.