### PR TITLE
Bumping stylelint-scss to 3.1.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stylelint-order": "^0.8.0",
     "stylelint-processor-html": "^1.0.0",
     "stylelint-rscss": "^0.4.0",
-    "stylelint-scss": "^2.2.0",
+    "stylelint-scss": "^3.1.3",
     "stylelint-selector-bem-pattern": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I noticed that stylelint-scss used an old version. This PR fixes it bu upgrading to the latest version.