### PR TITLE
Adds stylelint-config-recommended-scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/ada032d755e8ee1de505/maintainability)](https://codeclimate.com/github/gilbarbara/codeclimate-stylelint/maintainability)
 
-A [Code Climate](http://codeclimate.com/) engine that wraps [stylelint](https://github.com/stylelint/stylelint).  
+A [Code Climate](http://codeclimate.com/) engine that wraps [stylelint](https://github.com/stylelint/stylelint).
 You can run it on your local environment using the Code Climate CLI, or on the hosted analysis platform.
 
-Stylelint is a tool to help you enforce consistent conventions and avoid errors in your stylesheets.  
+Stylelint is a tool to help you enforce consistent conventions and avoid errors in your stylesheets.
 It can be configured using a [configuration file](http://stylelint.io/user-guide/configuration/).
 
 ### Installation
 
 1. If you haven't already, [install the Code Climate CLI](https://github.com/codeclimate/codeclimate).
-2. Run `codeclimate engines:enable stylelint`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
+2. Run `codeclimate engines:install stylelint`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
 3. Add a stylelint [config](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#loading-the-configuration-object) file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
@@ -28,6 +28,7 @@ It can be configured using a [configuration file](http://stylelint.io/user-guide
 - [stylelint-config-css-modules](https://github.com/pascalduez/stylelint-config-css-modules): CSS modules shareable config
 - [stylelint-config-wordpress](https://github.com/ntwb/stylelint-config-wordpress/): WordPress CSS Coding Standards shareable config
 - [stylelint-rscss](https://github.com/rstacruz/stylelint-rscss): Validate RSCSS conventions.
+- [stylelint-config-recommended-scss](https://github.com/kristerkari/stylelint-config-recommended-scss): Community driven SCSS config
 
 ### Plugins
 
@@ -51,7 +52,7 @@ This engine has support for some of the [recommended](https://github.com/styleli
 
 ## Development
 
-If you want to run the code locally, you'll need to install [docker](https://www.docker.com/) and build the image.  
+If you want to run the code locally, you'll need to install [docker](https://www.docker.com/) and build the image.
 Navigate to the project in your terminal and run:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -5097,6 +5097,14 @@
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz",
       "integrity": "sha512-ajMbivOD7JxdsnlS5945KYhvt7L/HwN6YeYF2BH6kE4UCLJR0YvXMf+2j7nQpJyYLZx9uZzU5G1ZOSBiWAc6yA=="
     },
+    "stylelint-config-recommended-scss": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.2.0.tgz",
+      "integrity": "sha512-M8BFHMRf8KNz5EQPKJd8nMCGmBd2o5coDEObfHVbEkyLDgjIf1V+U5dHjaGgvhm0zToUxshxN+Gc5wpbOOew4g==",
+      "requires": {
+        "stylelint-config-recommended": "^2.0.0"
+      }
+    },
     "stylelint-config-sass-guidelines": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "simple-git": "^1.96.0",
     "stylelint": "^9.3.0",
     "stylelint-config-css-modules": "^1.3.0",
+    "stylelint-config-recommended-scss": "^3.2.0",
     "stylelint-config-sass-guidelines": "^5.0.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-config-suitcss": "^14.0.0",


### PR DESCRIPTION
This PR adds in the community driven SCSS config mentioned on the https://stylelint.io/ homepage. 

I've also updated the README to suit, but also amended the instructions on testing the engine locally, the latest `codeclimate-cli` seems to use `engine:install` rather than `engine:enable`