### PR TITLE
Add support for styled components

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ It can be configured using a [configuration file](http://stylelint.io/user-guide
 - [stylelint-config-css-modules](https://github.com/pascalduez/stylelint-config-css-modules): CSS modules shareable config
 - [stylelint-config-wordpress](https://github.com/ntwb/stylelint-config-wordpress/): WordPress CSS Coding Standards shareable config
 - [stylelint-rscss](https://github.com/rstacruz/stylelint-rscss): Validate RSCSS conventions.
+- [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended): The recommended shareable config
+- [stylelint-config-styled-components](https://github.com/styled-components/stylelint-config-styled-components): The shareable stylelint config for stylelint-processor-styled-components
 
 ### Plugins
 
@@ -48,6 +50,7 @@ This engine has support for some of the [recommended](https://github.com/styleli
 
 - [stylelint-processor-html](https://github.com/ccbikai/stylelint-processor-html): Lint within HTML `<style>` tags. ***DEPRECATED***
 - [stylelint-processor-arbitrary-tags](https://github.com/mapbox/stylelint-processor-arbitrary-tags): A stylelint processor that allows you to lint CSS within arbitrary tags
+- [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components): Lint styles written for styled components
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,6 +4834,11 @@
         "stylelint-config-recommended": "^2.1.0"
       }
     },
+    "stylelint-config-styled-components": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz",
+      "integrity": "sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q=="
+    },
     "stylelint-config-suitcss": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-suitcss/-/stylelint-config-suitcss-14.0.0.tgz",
@@ -5015,6 +5020,74 @@
       "integrity": "sha1-aJK2soVaRfApHNhFGR1pCBMKKRg=",
       "requires": {
         "htmlparser2": "^3.9.1"
+      }
+    },
+    "stylelint-processor-styled-components": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.5.2.tgz",
+      "integrity": "sha512-sjOU/GtTQMR1McdntJWo6Za1wbdl5YuxQwWm5l2Nz6ELYoVI9WJTZbU9DQcvkOGjW3+HEk4ZKBytqFrMJPIx9Q==",
+      "requires": {
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "postcss": {
+          "version": "7.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "stylelint-rscss": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "simple-git": "^1.107.0",
     "stylelint": "^9.9.0",
     "stylelint-config-css-modules": "^1.3.0",
+    "stylelint-config-recommended": "^2.1.0",
     "stylelint-config-sass-guidelines": "^5.3.0",
     "stylelint-config-standard": "^18.2.0",
+    "stylelint-config-styled-components": "^0.1.1",
     "stylelint-config-suitcss": "^14.0.0",
     "stylelint-config-wordpress": "^13.1.0",
     "stylelint-csstree-validator": "^1.3.0",
@@ -40,6 +42,7 @@
     "stylelint-declaration-use-variable": "^1.7.0",
     "stylelint-order": "^2.0.0",
     "stylelint-processor-html": "^1.0.0",
+    "stylelint-processor-styled-components": "^1.5.2",
     "stylelint-rscss": "^0.4.0",
     "stylelint-scss": "^3.4.4",
     "stylelint-selector-bem-pattern": "^2.0.0"


### PR DESCRIPTION
[`styled-components`](https://github.com/styled-components/styled-components) is a popular css-in-js library and `stylelint` is the tool of choice to do linting of the css parts.

This pull request adds linting support for this framework. For details see #25 