### PR TITLE
Properly set code's path

### DIFF
--- a/bin/codeclimate-stylelint.js
+++ b/bin/codeclimate-stylelint.js
@@ -4,6 +4,8 @@
 const stylelint = require('stylelint');
 const fs = require('fs');
 const glob = require('glob');
+const CONFIG_PATH = "/config.json"
+const CODE_PATH = "/code"
 
 const rules = JSON.parse(fs.readFileSync(`${__dirname}/../config/contents/rules.json`, 'utf-8'));
 const options = { extensions: ['.css', '.scss', '.sass', '.less', '.sss', '.html', '.vue', '.js', '.jsx', '.ts', '.tsx'] };
@@ -105,8 +107,8 @@ function configEngine() {
   const engineTiming = runTiming('engineConfig');
   let buildFileList;
 
-  if (fs.existsSync('/config.json')) {
-    engineConfig = JSON.parse(fs.readFileSync('/config.json'));
+  if (fs.existsSync(CONFIG_PATH)) {
+    engineConfig = JSON.parse(fs.readFileSync(CONFIG_PATH));
 
     if (engineConfig.include_paths) {
       buildFileList = inclusionBasedFileListBuilder(engineConfig.include_paths);
@@ -148,7 +150,7 @@ function analyzeFiles() {
 
   stylelint
     .lint({
-      configBasedir: `${__dirname}/..`,
+      configBasedir: CODE_PATH,
       configFile: options.configFile,
       configOverrides: options.configOverrides,
       files: analysisFiles

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 SOURCE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
Looks like the plugin is not using the correct path for the code. We noticed this due to an apparently ignored stylelint configuration. Where we indicated some files to be ignored but they were analyzed despite that. When using styelint's cli the files were properly ignored.

Setting code's path as done in many others codeclimate plugins solves the issue. 

You can use the attached file to reproduce the problem. 
[stylelint-test-master.zip](https://github.com/gilbarbara/codeclimate-stylelint/files/5945862/stylelint-test-master.zip)


